### PR TITLE
Add feature to force SDR for ImprovedTube#694

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "السماح لـ60إطار"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "دائما نشط"

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "السماح لـ60إطار"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "دائما نشط"
     },

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "60 ফ্রেম প্রতি সেকেন্ অনুমতি দিনড"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "সর্বদা সক্রিয়"

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "60 ফ্রেম প্রতি সেকেন্ অনুমতি দিনড"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "সর্বদা সক্রিয়"
     },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "60fps zulassen"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Immer aktiv"
     },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "60fps zulassen"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Immer aktiv"

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Επίτρεψε 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Πάντοτε ενεργό"

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Επίτρεψε 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Πάντοτε ενεργό"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Allow 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Always active"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Allow 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Always active"
     },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Permitir 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Siempre activo"
     },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Permitir 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Siempre activo"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Jouer à 60 fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Toujours activé"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Jouer à 60 fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Toujours activé"
     },

--- a/_locales/hin/messages.json
+++ b/_locales/hin/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "60fps की अनुमति दें"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "हमेशा सक्रिय"

--- a/_locales/hin/messages.json
+++ b/_locales/hin/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "60fps की अनुमति दें"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "हमेशा सक्रिय"
     },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -41,6 +41,9 @@
     "allow60fps": {
         "message": "Izinkan 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Selalu aktif"
     },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -41,8 +41,8 @@
     "allow60fps": {
         "message": "Izinkan 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Selalu aktif"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Permetti 60 fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Sempre attivo"
     },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Permetti 60 fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Sempre attivo"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "60fpsを許可する"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "常に有効"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "60fpsを許可する"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "常に有効"
     },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "60에프피에스(fps) 허용"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "항상 활성화"
     },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "60에프피에스(fps) 허용"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "항상 활성화"

--- a/_locales/nb_NO/messages.json
+++ b/_locales/nb_NO/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Tillat 60 bps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Alltid aktiv"
     },

--- a/_locales/nb_NO/messages.json
+++ b/_locales/nb_NO/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Tillat 60 bps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Alltid aktiv"

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "60fps toestaan"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Altijd actief"
     },

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "60fps toestaan"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Altijd actief"

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Tillat 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Alltid aktiv"

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Tillat 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Alltid aktiv"
     },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Permitir 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Sempre ativo"
     },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Permitir 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Sempre ativo"

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Permitir 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Sempre ativo"
     },

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Permitir 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Sempre ativo"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Разрешить 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Всегда активный"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Разрешить 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Всегда активный"
     },

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "Povoliť 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Vždy aktívne"
     },

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "Povoliť 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Vždy aktívne"

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "60fps'e izin ver"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "Sürekli etkin"

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "60fps'e izin ver"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "Sürekli etkin"
     },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "允许60FPS"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "始终启用"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "允许60FPS"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "始终启用"
     },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -38,6 +38,9 @@
     "allow60fps": {
         "message": "允許 60fps"
     },
+    "allowHDR": {
+        "message": "Allow HDR"
+    },
     "alwaysActive": {
         "message": "始終有效"
     },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -38,8 +38,8 @@
     "allow60fps": {
         "message": "允許 60fps"
     },
-    "allowHDR": {
-        "message": "Allow HDR"
+    "forceSDR": {
+        "message": "Force SDR"
     },
     "alwaysActive": {
         "message": "始終有效"

--- a/popup.js
+++ b/popup.js
@@ -2209,10 +2209,10 @@ Menu.main.section.player = {
             label: 'allow60fps',
             value: true
         },
-        player_HDR: {
+        player_SDR: {
             type: 'switch',
-            label: 'allowHDR',
-            value: true
+            label: 'forceSDR',
+            value: false
         },
     },
 

--- a/popup.js
+++ b/popup.js
@@ -2209,6 +2209,11 @@ Menu.main.section.player = {
             label: 'allow60fps',
             value: true
         },
+        player_HDR: {
+            type: 'switch',
+            label: 'allowHDR',
+            value: true
+        },
     },
 
     section_label__audio: {

--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -51,7 +51,7 @@
   4.15 Repeat
   4.16 Rotate
   4.17 Popup player
-  4.18 Allow HDR
+  4.18 Force SDR
 5.0 Playlist
   5.1 Up next autoplay
   5.2 Reverse
@@ -179,7 +179,7 @@ ImprovedTube.DOMContentLoaded = function() {
 ImprovedTube.init = function() {
     this.playerH264();
     this.player60fps();
-    this.playerHDR();
+    this.playerSDR();
     this.pageType();
     this.shortcuts();
     this.DOMContentLoaded();
@@ -2148,11 +2148,11 @@ ImprovedTube.playerPopupButton = function() {
 };
 
 /*------------------------------------------------------------------------------
-4.18 ALLOW HDR
+4.18 Force SDR
 ------------------------------------------------------------------------------*/
 
-ImprovedTube.playerHDR = function() {
-    if (this.storage.player_HDR === false) {
+ImprovedTube.playerSDR = function() {
+    if (this.storage.player_SDR === true) {
           Object.defineProperty(window.screen, "pixelDepth", {
             enumerable: true,
             configurable: true,

--- a/youtube-scripts.js
+++ b/youtube-scripts.js
@@ -51,6 +51,7 @@
   4.15 Repeat
   4.16 Rotate
   4.17 Popup player
+  4.18 Allow HDR
 5.0 Playlist
   5.1 Up next autoplay
   5.2 Reverse
@@ -178,6 +179,7 @@ ImprovedTube.DOMContentLoaded = function() {
 ImprovedTube.init = function() {
     this.playerH264();
     this.player60fps();
+    this.playerHDR();
     this.pageType();
     this.shortcuts();
     this.DOMContentLoaded();
@@ -554,7 +556,7 @@ ImprovedTube.markWatchedVideos = function() {
 
                 button.className = 'it-mark-watched' + (this.storage.watched && this.storage.watched[this.getParam(new URL(video_items[i].href || 'https://www.youtube.com/').search.substr(1), 'v')] ? ' watched' : '');
                 button.innerHTML = '<svg viewBox="0 0 24 24"><path d="M12 4.5C7 4.5 2.7 7.6 1 12a11.8 11.8 0 0022 0c-1.7-4.4-6-7.5-11-7.5zM12 17a5 5 0 110-10 5 5 0 010 10zm0-8a3 3 0 100 6 3 3 0 000-6z"/></svg>';
-                
+
                 button.addEventListener('click', function(event) {
                     var watched = this.classList.contains('watched') ? false : true;
 
@@ -2145,6 +2147,19 @@ ImprovedTube.playerPopupButton = function() {
     }
 };
 
+/*------------------------------------------------------------------------------
+4.18 ALLOW HDR
+------------------------------------------------------------------------------*/
+
+ImprovedTube.playerHDR = function() {
+    if (this.storage.player_HDR === false) {
+          Object.defineProperty(window.screen, "pixelDepth", {
+            enumerable: true,
+            configurable: true,
+            value: 24
+          });
+    }
+};
 
 /*------------------------------------------------------------------------------
 5.0 PLAYLIST


### PR DESCRIPTION
Non HDR video options are not available when HDR is enabled in windows. Browser HDR is extremly laggy so users who have HDR enabled on windows currently have no way of playing SDR videos for smooth playback.

Add feature to force SDR which sets Window.screen.pixelDepth to 24 for computers that support 30+ (HDR) to trick Youtube into thinking HDR is not supported, allowing the user to select non HDR videos when HDR is enabled in windows.

